### PR TITLE
[feat/#17]: 광고 메인 페이지 기능 구현 (디자인 수정 반영)

### DIFF
--- a/src/main/java/com/unithon/domain/advertisement/application/AdvertisementService.java
+++ b/src/main/java/com/unithon/domain/advertisement/application/AdvertisementService.java
@@ -5,6 +5,7 @@ import com.unithon.domain.advertisement.dto.AdvertisementDTO;
 import java.util.List;
 
 public interface AdvertisementService {
-    List<AdvertisementDTO.AdStatusResponse> getFundingAdvertisements();
+    public AdvertisementDTO.MainResponse getAdvertisementsMain(
+            String status, String sort, int page, int size);
     AdvertisementDTO.AdvertisementDetailResponse getAdvertisementDetail(Long advertisementId);
 }

--- a/src/main/java/com/unithon/domain/advertisement/application/AdvertisementServiceImpl.java
+++ b/src/main/java/com/unithon/domain/advertisement/application/AdvertisementServiceImpl.java
@@ -9,12 +9,13 @@ import com.unithon.domain.advertisement.dto.AdvertisementDTO;
 import com.unithon.domain.donation.repository.DonationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,12 +25,66 @@ public class AdvertisementServiceImpl implements AdvertisementService{
     private final AdvertisementRepository advertisementRepository;
 
     @Override
-    public List<AdvertisementDTO.AdStatusResponse> getFundingAdvertisements() {
-        List<AdQueryResultInterface> results = advertisementRepository.findAllByStatusWithDetails("FUNDING");
+    public AdvertisementDTO.MainResponse getAdvertisementsMain(String statusStr, String sortStr, int page, int size) {
+        // --- 1. 요약 정보 조회 ---
+        Object[] summaryData;
+        if (statusStr == null || statusStr.isBlank()) { // 전체
+            summaryData = advertisementRepository.findSummaryInfoAll().get(0);
+            log.info("전체 광고 리스트에 걸렸습니다. summaryData [0] [1] [2]:: {}, {}", summaryData, summaryData[0]);
+        } else { // 상태별로
+            summaryData = advertisementRepository.findSummaryInfoByStatus(Status.valueOf(statusStr)).get(0);
+            log.info("상태 광고 리스트에 걸렸습니다 . summaryData [0] [1] [2]:: {}, {}", summaryData, summaryData[0]);
+        }
 
-        return results.stream()
-                .map(AdvertisementConverter::convertToAdStatusDTO)
+        AdvertisementDTO.SummaryInfo summaryInfo = AdvertisementDTO.SummaryInfo.builder()
+                .fundingProjectCount(summaryData[0] != null ? (Long) summaryData[0] : 0L)
+                .totalDonorCount(summaryData[1] != null ? (Long) summaryData[1] : 0L)
+                .totalFundingAmount(summaryData[2] != null ? (Long) summaryData[2] : 0L)
+                .build();
+
+        // --- 2. 정렬 조건 생성 ---
+        Sort sort = switch (sortStr) {
+            case "closingSoon" -> Sort.by(Sort.Direction.ASC, "endDate"); // 마감임박순
+            case "highestAmount" -> Sort.by(Sort.Direction.DESC, "currentAmount"); // 모금액순
+            default -> Sort.by(Sort.Direction.DESC, "createdAt"); // 최신순
+        };
+
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        // --- 3. 필터링 조건에 따라 광고 목록(Page) 조회 (1차 쿼리) ---
+        Page<Advertisement> adPage;
+        if (statusStr == null || statusStr.isBlank()) { // 전체
+            adPage = advertisementRepository.findAll(pageable);
+        } else { // 진행중/완료
+            adPage = advertisementRepository.findByStatus(Status.valueOf(statusStr), pageable);
+        }
+
+        if (!adPage.hasContent()) {
+            // 조회된 광고가 없으면 빈 응답 반환
+            return AdvertisementConverter.toMainResponse(summaryInfo, Collections.emptyList(), adPage);
+        }
+
+        // --- 4. 후원자 수 조회를 위한 ID 목록 추출 및 2차 쿼리 실행 ---
+        List<Long> adIds = adPage.getContent().stream()
+                .map(Advertisement::getAdvertisementId)
                 .collect(Collectors.toList());
+
+        // [광고 ID, 후원자 수] Map 생성 (조회를 쉽게 하기 위함)
+        Map<Long, Long> donorCountsMap = advertisementRepository.findDonorCountsByAdvertisementIds(adIds).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
+        // --- 5. 최종 DTO 리스트 생성 ---
+        List<AdvertisementDTO.AdvertisementCard> adCards = adPage.getContent().stream()
+                .map(ad -> {
+                    // Map에서 해당 광고의 후원자 수를 찾음. 없으면 0으로 처리.
+                    Long donorCount = donorCountsMap.getOrDefault(ad.getAdvertisementId(), 0L);
+                    // Converter에 엔티티와 후원자 수를 함께 넘겨줌
+                    return AdvertisementConverter.toAdvertisementCard(ad, donorCount);
+                })
+                .collect(Collectors.toList());
+
+        // --- 6. 최종 응답 DTO 조립 및 반환 ---
+        return AdvertisementConverter.toMainResponse(summaryInfo, adCards, adPage);
     }
 
     @Override

--- a/src/main/java/com/unithon/domain/advertisement/controller/AdvertisementController.java
+++ b/src/main/java/com/unithon/domain/advertisement/controller/AdvertisementController.java
@@ -13,10 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -31,8 +28,14 @@ public class AdvertisementController {
      * 현재 펀딩 중인 모든 광고 리스트 조회 (인증 불필요)
      */
     @GetMapping
-    public BaseResponse<List<AdvertisementDTO.AdStatusResponse>> getAllFundingAdvertisements() {
-        List<AdvertisementDTO.AdStatusResponse> response = advertisementService.getFundingAdvertisements();
+    public BaseResponse<AdvertisementDTO.MainResponse> getAdvertisements(
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "9") int size
+    ) {
+        AdvertisementDTO.MainResponse response =
+                advertisementService.getAdvertisementsMain(status, sort, page, size);
         return BaseResponse.onSuccess(SuccessStatus.ADVERTISEMENT_LIST_SUCCESS, response);
     }
 

--- a/src/main/java/com/unithon/domain/advertisement/converter/AdvertisementConverter.java
+++ b/src/main/java/com/unithon/domain/advertisement/converter/AdvertisementConverter.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.unithon.domain.advertisement.dto.AdvertisementDTO;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -21,23 +22,49 @@ public class AdvertisementConverter {
 
     // 광고현황 - 메인 DTO
 
-    public static AdvertisementDTO.AdStatusResponse convertToAdStatusDTO(AdQueryResultInterface result) {
-        // 남은 일수 계산
-        long remainingDays = ChronoUnit.DAYS.between(LocalDate.now(), result.getEndDate());
-        if (remainingDays < 0) {
-            remainingDays = 0;
+    public static AdvertisementDTO.MainResponse toMainResponse(
+            AdvertisementDTO.SummaryInfo summaryInfo,
+            List<AdvertisementDTO.AdvertisementCard> adCards,
+            Page<Advertisement> adPage) {
+
+        AdvertisementDTO.Pagination pagination = AdvertisementDTO.Pagination.builder()
+                .currentPage(adPage.getNumber())
+                .totalPages(adPage.getTotalPages())
+                .totalElements(adPage.getTotalElements())
+                .build();
+
+        return AdvertisementDTO.MainResponse.builder()
+                .summaryInfo(summaryInfo)
+                .advertisements(adCards)
+                .pagination(pagination)
+                .build();
+    }
+
+    /**
+     * Advertisement 엔티티와 후원자 수를 받아 광고 카드 DTO로 변환합니다.
+     * @param ad Advertisement 엔티티
+     * @param donorCount 해당 광고의 후원자 수
+     * @return AdvertisementCard DTO
+     */
+    public static AdvertisementDTO.AdvertisementCard toAdvertisementCard(Advertisement ad, Long donorCount) {
+        long remainingDays = ChronoUnit.DAYS.between(LocalDate.now(), ad.getEndDate());
+        if (remainingDays < 0) remainingDays = 0;
+
+        int progressPercentage = 0;
+        if (ad.getGoalAmount() > 0) {
+            progressPercentage = (int) (((double) ad.getCurrentAmount() / ad.getGoalAmount()) * 100);
         }
 
-        return AdvertisementDTO.AdStatusResponse.builder()
-                .advertisementId(result.getAdvertisementId())
-                .adTitle(result.getAdTitle())
-                .artistName(result.getArtistName())
-                .imageUrl(result.getImageUrl())
-                .mediaType(MediaType.valueOf(result.getMediaType())) // String -> Enum 변환
-                .currentAmount(result.getCurrentAmount())
-                .goalAmount(result.getGoalAmount())
-                .donorCount(result.getDonorCount())
+        return AdvertisementDTO.AdvertisementCard.builder()
+                .advertisementId(ad.getAdvertisementId())
+                .purpose(ad.getPurpose())
+                .artistName(ad.getArtistId().getName())
+                .title(ad.getName())
+                .progressPercentage(progressPercentage)
+                .currentAmount(ad.getCurrentAmount())
+                .donorCount(donorCount) // 계산된 값을 직접 주입
                 .remainingDays(remainingDays)
+                .imageUrl(ad.getImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/unithon/domain/advertisement/domain/repository/AdvertisementRepository.java
+++ b/src/main/java/com/unithon/domain/advertisement/domain/repository/AdvertisementRepository.java
@@ -5,6 +5,8 @@ import com.unithon.domain.advertisement.domain.entity.Status;
 import com.unithon.domain.advertisement.dto.AdvertisementDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,28 +15,34 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AdvertisementRepository extends JpaRepository<Advertisement, Long> {
+    // --- 광고 목록 조회를 위한 기본 메서드 ---
+    // status 필터링이 필요하므로, 상태별로 페이지를 찾는 메서드를 정의합니다.
+    Page<Advertisement> findByStatus(Status status, Pageable pageable);
+
+    // --- 요약 정보 조회를 위한 메서드 ---
+    // [수정] 반환 타입을 List<Object[]> 로 변경
+    // [수정] 총 모금액을 ad.currentAmount의 합으로 변경, [총광고수, 모금한사람, 총모금액]
+    @Query("SELECT COUNT(ad.advertisementId), COUNT(DISTINCT d.user.id), COALESCE(SUM(ad.currentAmount), 0) " +
+            "FROM Advertisement ad LEFT JOIN Donation d ON d.advertisement = ad")
+    List<Object[]> findSummaryInfoAll();
+
+    // 2. 상태별 요약 정보
+    @Query("SELECT COUNT(ad.advertisementId), COUNT(DISTINCT d.user.id), COALESCE(SUM(ad.currentAmount), 0) " +
+            "FROM Advertisement ad LEFT JOIN Donation d ON d.advertisement = ad WHERE ad.status = :status")
+    List<Object[]> findSummaryInfoByStatus(@Param("status") Status status);
+
+    // --- [중요] 후원자 수 N+1 문제 해결을 위한 쿼리 ---
     /**
-     * [최종 쿼리] 특정 상태(status)의 모든 광고 목록을 상세 정보와 함께 조회
-     * @param status 필터링할 광고 상태 (e.g., "FUNDING")
-     * @return 광고 상세 정보를 담은 인터페이스 리스트
+     * 주어진 광고 ID 목록에 해당하는 각 광고의 후원자 수를 조회합니다.
+     * @param adIds 광고 ID 리스트
+     * @return [광고 ID, 후원자 수] 형태의 Object 배열 리스트
      */
-    @Query(value = "SELECT " +
-            "    ad.advertisement_id AS advertisementId, " +
-            "    ad.name AS adTitle, " +
-            "    ar.name AS artistName, " +
-            "    ad.image_url AS imageUrl, " +
-            "    ad.media_type AS mediaType, " +
-            "    ad.end_date AS endDate, " +
-            "    ad.current_amount AS currentAmount, " +
-            "    ad.goal_amount AS goalAmount, " +
-            "    COUNT(d.donation_id) AS donorCount " +
-            "FROM advertisement ad " +
-            "LEFT JOIN artist ar ON ad.artist_id = ar.artist_id " +
-            "LEFT JOIN donation d ON ad.advertisement_id = d.advertisement_id " +
-            "WHERE ad.status = :status " +
-            "GROUP BY ad.advertisement_id, ar.name " +
-            "ORDER BY ad.end_date ASC", nativeQuery = true)
-    List<AdQueryResultInterface> findAllByStatusWithDetails(@Param("status") String status);
+    @Query("SELECT d.advertisement.advertisementId, COUNT(d.id) " +
+            "FROM Donation d " +
+            "WHERE d.advertisement.advertisementId IN :adIds " +
+            "GROUP BY d.advertisement.advertisementId")
+    List<Object[]> findDonorCountsByAdvertisementIds(@Param("adIds") List<Long> adIds);
+
 
     /**
      * 광고 상세 정보와 해당 광고의 총 후원자 수를 한 번의 쿼리로 조회

--- a/src/main/java/com/unithon/domain/advertisement/dto/AdvertisementDTO.java
+++ b/src/main/java/com/unithon/domain/advertisement/dto/AdvertisementDTO.java
@@ -2,28 +2,61 @@ package com.unithon.domain.advertisement.dto;
 
 import com.unithon.domain.advertisement.domain.entity.Advertisement;
 import com.unithon.domain.advertisement.domain.entity.MediaType;
+import com.unithon.domain.advertisement.domain.entity.Purpose;
 import lombok.*;
+
+import java.util.List;
 
 public class AdvertisementDTO {
 
     /**
-     * 광고 현황 리스트 각 아이템에 대한 최종 응답 DTO
+     * 광고 메인 페이지 DTO
+     */
+    @Builder
+    @Getter
+    public static class MainResponse {
+        private SummaryInfo summaryInfo;
+        private List<AdvertisementCard> advertisements;
+        private Pagination pagination; // 페이지네이션 정보 추가
+    }
+
+    /**
+     * 상단 요약 정보 카드 DTO
+     */
+    @Builder
+    @Getter
+    public static class SummaryInfo {
+        private long fundingProjectCount; // 진행 중인 프로젝트 수
+        private long totalDonorCount;     // 총 참여자 수
+        private long totalFundingAmount;  // 총 모금액
+    }
+
+    /**
+     * 광고 카드 하나를 나타내는 DTO
      */
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @ToString
-    public static class AdStatusResponse {
+    public static class AdvertisementCard {
         private Long advertisementId;
-        private String adTitle; // BTS 지하철 광고
-        private String artistName; // BTS
-        private String imageUrl; // 섬네일 이미지
-        private MediaType mediaType; // SUBWAY, BUS
-        private int currentAmount; // 현재 금액 수
-        private int goalAmount; // 목표 금액 수
-        private Long donorCount; // 후원자 수
-        private Long remainingDays; // 남은 일수
+        private Purpose purpose;          // 생일 광고, 기타 응원 등
+        private String artistName;
+        private String title;
+        private int progressPercentage;   // 진행률
+        private int currentAmount;        // 현재 모금액
+        private Long donorCount;          // 참여자 수
+        private Long remainingDays;       // 남은 기간
+      //  private String location;          // 광고 장소 (e.g., 타임스퀘어 전광판)
+        private String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    public static class Pagination {
+        private int currentPage;
+        private int totalPages;
+        private long totalElements;
     }
 
     /**


### PR DESCRIPTION
광고 메인 페이지 API 테스트


 [Test 1] 기본 요청 (전체 목록, 최신순, 첫 페이지)
파라미터 없이 보냈을 때 기본값(sort=latest, page=0, size=9)이 잘 동작하는지 확인
GET localhost:8080/advertisements


[Test 2] 진행중(FUNDING) 목록만 필터링
status=FUNDING 파라미터를 추가하여 '진행중' 탭을 눌렀을 때의 상황을 테스트
GET http://localhost:8080/api/advertisements?status=FUNDING


[Test 3] 완료(COMPLETED) 목록만 필터링
GET localhost:8080/advertisements?status=FUNDED


[Test 4] 정렬: 마감임박순
sort=closingSoon 파라미터를 추가하여 마감일이 가까운 순서대로 정렬되는지 확인
 결과 리스트의 'remainingDays' 값이 오름차순으로 정렬되어야 함
GET localhost:8080/advertisements?sort=closingSoon


 [Test 5] 정렬: 모금액순
 sort=highestAmount 파라미터를 추가하여 모금액이 높은 순서대로 정렬되는지 확인
 결과 리스트의 'currentAmount' 값이 내림차순으로 정렬되어야 함
GET localhost:8080/advertisements?sort=highestAmount




 [Test 8] 복합 조건: 진행중 + 마감임박순 + 두 번째 페이지
 여러 파라미터를 조합하여 복합적인 조건에서도 API가 정상 동작하는지 최종 확인
GET localhost:8080/advertisements?status=FUNDING&sort=closingSoon

+ 인기순 정렬
GET localhost:8080/advertisements?sort=popular